### PR TITLE
constexpr pi

### DIFF
--- a/src/rti/device.hpp
+++ b/src/rti/device.hpp
@@ -59,6 +59,11 @@ namespace rti {
       spacing = spacing_;
     }
 
+    void set_grid_spacing(numeric_type spacing_) {
+      spacing.clear();
+      spacing.push_back(spacing_);
+    }
+
     void set_number_of_rays(size_t numofrays_)
     {
       numofrays = numofrays_;
@@ -207,16 +212,20 @@ namespace rti {
     combine_points_with_grid_spacing_and_compute_max_disc_radius()
     {
       auto result = std::vector<util::quadruple<numeric_type> > {};
-      assert(points.size() == spacing.size() && "Assumption");
-      maxDscRad = 0.0;
+      const auto num_spacings = spacing.size();
+      assert((points.size() == num_spacings || num_spacings == 1) && "Assumption");
+      maxDscRad = spacing[0];
+      auto sca = spacing[0];
       result.reserve(points.size());
       for (size_t idx = 0; idx < points.size(); ++idx) {
-        auto tri = points[idx];
-        auto sca = spacing[idx];
-        result.push_back({tri[0], tri[1], tri[2], sca});
-        if (maxDscRad < sca) {
-          maxDscRad = sca;
+        const auto& tri = points[idx];
+        if(num_spacings != 1){
+          sca = spacing[idx];
+          if (maxDscRad < sca) {
+            maxDscRad = sca;
+          }
         }
+        result.push_back({tri[0], tri[1], tri[2], sca});
       }
       return result;
     }

--- a/src/rti/geo/boundary_x_y.hpp
+++ b/src/rti/geo/boundary_x_y.hpp
@@ -95,7 +95,7 @@ namespace rti { namespace geo {
       auto xx = rayin.org_x + rayin.dir_x * rayin.tfar;
       auto yy = rayin.org_y + rayin.dir_y * rayin.tfar;
       auto zz = rayin.org_z + rayin.dir_z * rayin.tfar;
-      auto const eps = 1e-6;
+      auto const eps = 1e-5;
       if (primID == xMaxTriIdcs[0] || primID == xMaxTriIdcs[1] ||
           primID == xMinTriIdcs[0] || primID == xMinTriIdcs[1]) {
         // X boundary

--- a/src/rti/util/utils.hpp
+++ b/src/rti/util/utils.hpp
@@ -11,7 +11,7 @@
 namespace rti { namespace util {
 
   //constexpr double pi() { return std::atan(1)*4; }
-  constexpr double pi() { return std::acos(-1); }
+  constexpr double pi() { return 3.141592653589793238462643383279502884L; }
   //constexpr auto pi = std::acos(-1);
 
   template<typename Ty>


### PR DESCRIPTION
Replaced std::acos(-1) with the actual number, as constexpr std:.acos(-1) is a GNU extension and not standard.